### PR TITLE
added wallet lock/unlock early

### DIFF
--- a/solarcoingenapi.py
+++ b/solarcoingenapi.py
@@ -24,6 +24,8 @@ energy_reporting_increment = 0.01
 inverter_query = 600
 
 solarcoin_passphrase = getpass.getpass(prompt="What is your SolarCoin Wallet Passphrase: ")
+subprocess.call(['solarcoind', 'walletlock'], shell=False)
+subprocess.call(['solarcoind', 'walletpassphrase', solarcoin_passphrase, '9999999', 'true'], shell=False)
 
 if os.path.isfile("APIlan.db"):
 	lan_wan = "y"	


### PR DESCRIPTION
added wallet locking and unlocking immediately after the getpass to ensure the passphrase is correct, prevents the code failing later while the user may not be present.